### PR TITLE
Change to the author's link in the author's card

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -79,7 +79,7 @@ ml-lab:
     image: "/images/ml-pac.png"
     bio: "Machine Learning &amp; Computer Vision team.<br>Machine learning solutions for every ZURU product."
 
-alepaoletti:
+alessio-paoletti:
     name: Alessio Paoletti
     uri: https://ale32.github.io/
     email: alessio.p@zuru.tech

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -49,8 +49,11 @@ layout: default
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-lg-10 col-md-10 col-sm-10">
-                                    <!-- If redirect to author page href="{{ author.uri }}" -->
+                                    {% if author.uri %}
+                                    <p class="author-name-title"><a href="{{ author.uri }}" class="author-name-link">{{ author.name }}</a> {{ author.bio }}</p>
+                                    {% else %}
                                     <p class="author-name-title"><a href="#" class="author-name-link">{{ author.name }}</a> {{ author.bio }}</p>
+                                    {% endif %}
                                     <div class="social-icon">
                                         {% if author.facebook %}
                                             <a href="{{ author.facebook }}" target="_blank" class="fa fa-facebook icon-maker"></a>

--- a/_posts/2020-04-23-rendering-in-UE4.md
+++ b/_posts/2020-04-23-rendering-in-UE4.md
@@ -1,5 +1,5 @@
 ---
-author: "alepaoletti"
+author: "alessio-paoletti"
 layout: post
 did: "blog10"
 title: "Real time rendering and Unreal Engine 4"


### PR DESCRIPTION
I've made a small change to the author's link in the author's card: it was pointing to the post itself, but I find it useful if it links to the author uri, if there's one.

I thought it could be better this way, otherwise the author uri seems never used.

I've changed my author id as well, as it's the one that is displayed on top of the article.

